### PR TITLE
import datetime for line 68

### DIFF
--- a/admin/pageaudit/report/import_csv.py
+++ b/admin/pageaudit/report/import_csv.py
@@ -1,4 +1,5 @@
 import csv
+import datetime
 
 field_names=['url', 'url2', 'views', 'hist', 'sequence',]
 


### PR DESCRIPTION
The issue on line 77 is also worth fixing because _undefined names_ have the potential to raise NameError at runtime.

[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/page-lab on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./admin/pageaudit/report/import_csv.py:67:75: F821 undefined name 'datetime'
                run_data = LighthouseRun.objects.filter(created_date__gte=datetime.date(y, m, d))
                                                                          ^
./admin/pageaudit/report/import_csv.py:76:44: F821 undefined name 'LighthouseDataUsertiming'
                    user_timing_data = str(LighthouseDataUsertiming.objects.get(lighthouse_run=run).report_data)
                                           ^
2     F821 undefined name 'datetime'
2
```