### PR TITLE
Undefined name: 'LighthouseDataUsertiming' in import_csv.py

### DIFF
--- a/admin/pageaudit/report/import_csv.py
+++ b/admin/pageaudit/report/import_csv.py
@@ -8,7 +8,8 @@ from django.db import transaction
 from django.db.models import Avg, Max, Min, Q, Sum
 from django.utils import timezone
 
-from report.models import Url, LighthouseRun, LighthouseDataRaw, UserTimingMeasureName, UserTimingMeasure, UserTimingMeasureAverage
+from report.models import (Url, LighthouseRun, LighthouseDataRaw, LighthouseDataUsertiming,
+                           UserTimingMeasureName, UserTimingMeasure, UserTimingMeasureAverage)
 
 
 superuser = User.objects.get(id=1)


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/page-lab on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./admin/pageaudit/report/import_csv.py:77:44: F821 undefined name 'LighthouseDataUsertiming'
                    user_timing_data = str(LighthouseDataUsertiming.objects.get(lighthouse_run=run).report_data)
                                           ^
1     F821 undefined name 'LighthouseDataUsertiming'
1
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree